### PR TITLE
Fixed Bug QTM8-21606: Automation API Key stored and displayed in plain text

### DIFF
--- a/src/main/java/com/qmetry/QTMReportPublisher.java
+++ b/src/main/java/com/qmetry/QTMReportPublisher.java
@@ -25,13 +25,14 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import jenkins.tasks.SimpleBuildStep;
 
 public class QTMReportPublisher extends Recorder implements SimpleBuildStep {
     
     private final boolean disableaction;
     private final String qtmUrl;
-    private final String qtmAutomationApiKey;
+    private final Secret qtmAutomationApiKey;
     private final String proxyUrl;
     private final String automationFramework;
     private final String automationHierarchy;
@@ -56,7 +57,7 @@ public class QTMReportPublisher extends Recorder implements SimpleBuildStep {
         
         this.disableaction = disableaction;
         this.qtmUrl = qtmUrl;
-        this.qtmAutomationApiKey = qtmAutomationApiKey;
+        this.qtmAutomationApiKey = Secret.fromString(qtmAutomationApiKey);
         this.proxyUrl = proxyUrl;
         this.automationFramework = automationFramework;
         this.automationHierarchy = automationHierarchy;
@@ -83,7 +84,7 @@ public class QTMReportPublisher extends Recorder implements SimpleBuildStep {
         return this.qtmUrl;
     }
     
-    public String getQtmAutomationApiKey() {
+    public Secret getQtmAutomationApiKey() {
         return this.qtmAutomationApiKey;
     }
 
@@ -174,7 +175,7 @@ public class QTMReportPublisher extends Recorder implements SimpleBuildStep {
                 listener.getLogger().println("-------------------------------------------------------------------------------");
                 String qtmUrl_chkd = StringUtils.trimToEmpty(getQtmUrl());
                 
-                String qtmAutomationApiKey_chkd = StringUtils.trimToEmpty(getQtmAutomationApiKey());
+                String qtmAutomationApiKey_chkd = StringUtils.trimToEmpty(Secret.toString(getQtmAutomationApiKey()));
 
                 String proxyUrl_chkd = StringUtils.trimToEmpty(getProxyUrl());
                 

--- a/src/main/resources/com/qmetry/QTMReportPublisher/config.jelly
+++ b/src/main/resources/com/qmetry/QTMReportPublisher/config.jelly
@@ -11,7 +11,7 @@
 		</f:entry>
 		
 		<f:entry title="Automation API Key" field="qtmAutomationApiKey">
-			<f:textbox placeholder="Your QMetry project automation API Key" />
+			<f:password placeholder="Your QMetry project automation API Key" />
 		</f:entry>
 
 		<f:entry title="Proxy URL" field="proxyUrl">


### PR DESCRIPTION
## Description

This PR addresses a critical security issue in the QMetry Test Management Plugin for Jenkins (v1.13), where QMetry Automation API keys were being stored and displayed in plain text. The fix ensures that sensitive credentials are now securely masked and stored using Jenkins' built-in credential management system.

### Changes Made
- Replaced plain text storage of API keys with encrypted credentials using Jenkins `Secret` class.
- Updated UI components to mask API keys from being displayed.
- Refactored configuration logic to support secure credential handling.

---

## Testing Done

- Verified the plugin behavior in a local Jenkins instance.
- Confirmed that API keys are no longer visible in the UI or logs.
- Ensured that existing functionality (test result uploads, API calls) continues to work with the new credential handling.
- Manually tested the plugin configuration page and job execution flow.

---

## Additional Notes

- Resolves a known security vulnerability reported in plugin version 1.13.
- No breaking changes introduced.
- Future enhancements may include migrating existing plain text keys to secure storage automatically.
